### PR TITLE
refactored code, moved from react pinch zoom to a custom component

### DIFF
--- a/app/lib/connect.tsx
+++ b/app/lib/connect.tsx
@@ -6,26 +6,26 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { call_rpc, get_hid_data, hid_usage_get_labels } from "@/lib/rpc";
+import { call_rpc } from "@/lib/rpc";
 import { useRpcStore } from "@/lib/store";
-import { create_rpc_connection, Response } from "@zmkfirmware/zmk-studio-ts-client";
+import {
+  create_rpc_connection,
+  Response,
+} from "@zmkfirmware/zmk-studio-ts-client";
 import { connect as serial_connect } from "@zmkfirmware/zmk-studio-ts-client/transport/serial";
 import { useEffect, useState } from "react";
 import { useShallow } from "zustand/shallow";
 
-function remove_prefix(s?: string) {
-  return s?.replace(/^Keyboard /, "");
-}
-
 export default function Connect() {
   const [open, setOpen] = useState(true);
 
-  const { setRpcConnection, setPhysicalLayouts, setSelectedLayout } =
+  const { setRpcConnection, setPhysicalLayouts, setSelectedLayout, setKeymap } =
     useRpcStore(
       useShallow((state) => ({
         setPhysicalLayouts: state.setPhysicalLayouts,
         setRpcConnection: state.setRpcConnection,
         setSelectedLayout: state.setSelectedLayout,
+        setKeymap: state.setKeymap,
       }))
     );
 
@@ -42,23 +42,20 @@ export default function Connect() {
 
     if (keymaps) {
       setPhysicalLayouts(keymaps);
+      //todo change this
       setSelectedLayout(0);
     }
 
     setRpcConnection(connection);
 
-    // this is just a test to see how to get the data
     response = await call_rpc(connection, {
-      keymap: { getKeymap: true }
+      keymap: { getKeymap: true },
     });
+  
+    if (response.keymap?.getKeymap) {
+      setKeymap(response.keymap.getKeymap);
+    }
 
-    console.log(response.keymap?.getKeymap?.layers[0].bindings[0])
-
-    let {page, id} = get_hid_data(response.keymap?.getKeymap?.layers[0].bindings[0].param1!)
-
-    let labels =  hid_usage_get_labels(page, id)
-
-    console.log(remove_prefix(labels.short))
     setOpen(false);
   };
 

--- a/app/lib/key.tsx
+++ b/app/lib/key.tsx
@@ -1,0 +1,31 @@
+import { Button } from "@/components/ui/button";
+import { get_hid_label, remove_keyboard_prefix } from "@/lib/rpc";
+import { useRpcStore } from "@/lib/store";
+import { KeyPhysicalAttrs } from "@zmkfirmware/zmk-studio-ts-client/keymap";
+
+type KeyProps = {
+  attr: KeyPhysicalAttrs;
+  idx: number;
+};
+export default function Key({ attr, idx }: KeyProps) {
+  const keyMap = useRpcStore((state) => state.keyMap);
+
+  let usage = keyMap?.layers[0].bindings[idx].param1;
+
+  let hidLabel = usage ? remove_keyboard_prefix(get_hid_label(usage).short) : undefined;
+
+  return (
+    <Button
+      variant={"outline"}
+      className="absolute"
+      style={{
+        width: `${attr.width}px`,
+        height: `${attr.height}px`,
+        top: `${attr.y}px`,
+        left: `${attr.x}px`,
+      }}
+    >
+      {hidLabel}
+    </Button>
+  );
+}

--- a/app/lib/keyboard.tsx
+++ b/app/lib/keyboard.tsx
@@ -3,6 +3,7 @@ import { useRpcStore } from "@/lib/store";
 import { KeyPhysicalAttrs } from "@zmkfirmware/zmk-studio-ts-client/keymap";
 import { useEffect } from "react";
 import { useShallow } from "zustand/shallow";
+import Key from "./key";
 
 export default function Keyboard() {
   const { physicalLayouts, selectedLayout } = useRpcStore(
@@ -31,17 +32,7 @@ export default function Keyboard() {
       style={{ width: `${width}px`, height: `${height}px` }}
     >
       {physicalLayouts[selectedLayout].keys.map((attr, idx) => (
-        <Button
-          variant={"outline"}
-          className="absolute"
-          key={`physKeys${idx}`}
-          style={{
-            width: `${attr.width}px`,
-            height: `${attr.height}px`,
-            top: `${attr.y}px`,
-            left: `${attr.x}px`,
-          }}
-        ></Button>
+        <Key attr={attr} idx={idx} key={`physKeys${idx}`} />
       ))}
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,26 +1,15 @@
 "use client";
-
-import { TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
 import Connect from "./lib/connect";
 import Keyboard from "./lib/keyboard";
+import CanvasPan from "@/components/canvas-pan";
 
 export default function Home() {
   return (
     <div className="">
       <Connect />
-      <TransformWrapper limitToBounds={false} minScale={0.25} maxScale={2.5}>
-        <TransformComponent
-          wrapperStyle={{
-            width: "100vw",
-            height: "100vh",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          <Keyboard />
-        </TransformComponent>
-      </TransformWrapper>
+      <CanvasPan className="h-screen w-screen">
+        <Keyboard />
+      </CanvasPan>
     </div>
   );
 }

--- a/components/canvas-pan.tsx
+++ b/components/canvas-pan.tsx
@@ -1,0 +1,51 @@
+import { cn } from "@/lib/utils";
+import { ReactNode, useRef, useState } from "react";
+
+type CanvasPanProps = {
+  children: ReactNode;
+  className: string;
+};
+
+export default function CanvasPan({ children, className }: CanvasPanProps) {
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const [isDragging, setDragging] = useState(false);
+  const lastPos = useRef({ x: 0, y: 0 });
+  const canvas = useRef<HTMLDivElement>(null);
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    if (e.target === canvas.current) {
+      setDragging(true)
+      lastPos.current = { x: e.clientX - pos.x, y: e.clientY - pos.y };
+    }
+  };
+
+  const onMouseMove = (e: React.MouseEvent) => {
+    if (isDragging) {
+      setPos({
+        x: e.clientX - lastPos.current.x,
+        y: e.clientY - lastPos.current.y,
+      });
+    }
+  };
+
+  const onMouseUp = () => {
+    setDragging(false)
+  };
+
+  return (
+    <div
+      onMouseDown={onMouseDown}
+      onMouseMove={onMouseMove}
+      onMouseUp={onMouseUp}
+      className={cn("overflow-hidden flex justify-center items-center", className)}
+      ref={canvas}
+      style={{ cursor: isDragging ? "grabbing" : "grab" }}
+    >
+      <div
+        style={{ transform: `translate(${pos.x}px, ${pos.y}px)` }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -4,8 +4,8 @@ import {
   RequestResponse,
   RpcConnection,
 } from "@zmkfirmware/zmk-studio-ts-client";
-import { usagePages } from "./hid_data/keyboard-and-consumer-usage-tables.json"
-import { hidOverrides } from "./hid_data/hid-usage-name-overrides.json"
+import { usagePages } from "./hid_data/keyboard-and-consumer-usage-tables.json";
+import { hidOverrides } from "./hid_data/hid-usage-name-overrides.json";
 
 interface HidLabels {
   short?: string;
@@ -33,38 +33,26 @@ export async function call_rpc(
 
 /**
  * from zmk-studio project
- * 
- * this gets the page and id from the value returned by using 
- * 
+ *
+ * this gets the hid label from a usage number
+ *
  * response = await call_rpc(connection, {
  *    keymap: { getKeymap: true }
  * });
- * 
- * this function extracts the upper 4 bytes as the page and the lower 4 bytes as the id
- * 
- * @param usage this is from response.keymap.layers.bindings[x].param1
+ *
+ * @param usage response.keymap.layers.bindings[x].param1
  */
-export function get_hid_data (usage:number): {page:number, id: number} {
-  return ({
-    page: (usage >> 16) & 0xffff,
-    id: usage & 0xffff
-  })
-}
+export function get_hid_label(usage: number): HidLabels {
+  let usage_page = (usage >> 16) & 0xff;
+  let usage_id = usage & 0xffff;
 
-
-/**
- * This is directly from zmk studio
- * 
- * @param usage_page 
- * @param usage_id 
- * @returns 
- */
-export const hid_usage_get_labels = (
-  usage_page: number,
-  usage_id: number
-): { short?: string; med?: string; long?: string } =>
-  overrides[usage_page.toString()]?.[usage_id.toString()] || {
+  return overrides[usage_page.toString()]?.[usage_id.toString()] || {
     short: usagePages.find((p) => p.Id === usage_page)?.UsageIds?.find(
       (u) => u.Id === usage_id
     )?.Name,
   };
+}
+
+export function remove_keyboard_prefix(s?: string) {
+  return s?.replace(/^Keyboard /, "");
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,21 +1,28 @@
 import { RpcConnection } from "@zmkfirmware/zmk-studio-ts-client";
-import { PhysicalLayout } from "@zmkfirmware/zmk-studio-ts-client/keymap";
+import {
+  Keymap,
+  PhysicalLayout,
+} from "@zmkfirmware/zmk-studio-ts-client/keymap";
 import { create } from "zustand";
 
 type RpcStore = {
   rpcConnection: RpcConnection | undefined;
   physicalLayouts: PhysicalLayout[] | undefined;
   selectedLayout: number | undefined;
+  keyMap: Keymap | undefined;
   setRpcConnection: (connection: RpcConnection) => void;
   setPhysicalLayouts: (layouts: PhysicalLayout[]) => void;
-  setSelectedLayout: (index: number) => void; 
+  setSelectedLayout: (index: number) => void;
+  setKeymap: (keymap: Keymap) => void;
 };
 
 export const useRpcStore = create<RpcStore>((set) => ({
   rpcConnection: undefined,
   physicalLayouts: undefined,
   selectedLayout: undefined,
+  keyMap: undefined,
   setRpcConnection: (connection) => set({ rpcConnection: connection }),
   setPhysicalLayouts: (layouts) => set({ physicalLayouts: layouts }),
-  setSelectedLayout: (index) => set({selectedLayout: index})
+  setSelectedLayout: (index) => set({ selectedLayout: index }),
+  setKeymap: (keymap) => set({ keyMap: keymap }),
 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "react-zoom-pan-pinch": "^3.7.0",
         "run-script-os": "^1.1.6",
         "tailwind-merge": "^3.3.1",
         "zustand": "^5.0.7"
@@ -2155,20 +2154,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-zoom-pan-pinch": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz",
-      "integrity": "sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
       }
     },
     "node_modules/run-script-os": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-zoom-pan-pinch": "^3.7.0",
     "run-script-os": "^1.1.6",
     "tailwind-merge": "^3.3.1",
     "zustand": "^5.0.7"


### PR DESCRIPTION
# Display HID Labels on Keyboard Keys

This PR adds functionality to display HID labels on keyboard keys:

- Implemented a new `Key` component to render individual keys with their HID labels
- Created utility functions to extract and format HID labels from key usage data
- Added keymap state management to the store
- Replaced the third-party zoom/pan library with a custom `CanvasPan` component
- Refactored code to improve organization and readability

The HID labels are now displayed on the keyboard, but the formatting could still use some improvements.